### PR TITLE
disable git autocorrect

### DIFF
--- a/dotfiles/gitconfig
+++ b/dotfiles/gitconfig
@@ -125,9 +125,5 @@
   # Detect copies as well as renames
   renames = copies
 
-[help]
-
-  # Automatically correct and execute mistyped commands
-  autocorrect = 1
 [include]
   path = ~/.gitconfig.local


### PR DESCRIPTION
as it can execute commands you didn't want to:
`git git` becomes `git init` and that's just horrible